### PR TITLE
docs(readme): add power sensor lamp automation blueprint to available blueprints table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ These blueprints are written with clarity, flexibility, and real-world usability
 | Blueprint                         | Description                                         | Docs |
 |----------------------------------|-----------------------------------------------------|------|
 | **Motion-Based Lighting v2.5**   | Adaptive lighting with smooth dimming, color temp, and per-room overrides | [View →](./blueprints/automation/johnstetter/motion_lighting_adaptive/README.md) |
+| **Power Sensor Lamp Automation** | Lamp control based on device power usage, adaptive lighting, and alert features | [View →](./blueprints/automation/johnstetter/power_sensor_lamp_automation/README.md) |
 
 > 💡 All blueprints are YAML-based, self-contained, and designed to work with native Home Assistant automations.
 


### PR DESCRIPTION
Closes #6

## Update README: Add Power Sensor Lamp Automation Blueprint

### Summary

- Added the **Power Sensor Lamp Automation** blueprint to the "Available Blueprints" table in the main `README.md`.
- Each blueprint now includes a clear description and a direct link to its documentation.

### Details

- The new entry highlights the lamp automation’s features: device power-based control, adaptive lighting, and alerting.
- Ensures users can easily discover and access both available blueprints.

### Motivation

This update keeps the documentation current and helps users quickly find and use all available blueprints in the repository.